### PR TITLE
Update IReactDeclarationGenerator.h for UE 5.3

### DIFF
--- a/Source/ReactDeclarationGenerator/Public/IReactDeclarationGenerator.h
+++ b/Source/ReactDeclarationGenerator/Public/IReactDeclarationGenerator.h
@@ -10,7 +10,9 @@
 
 #include <cstdio>
 
+#if ENGINE_MAJOR_VERSION < 5 || ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION < 2
 #include "IScriptGeneratorPluginInterface.h"
+#endif
 #include "Modules/ModuleManager.h"
 #include "CoreMinimal.h"
 


### PR DESCRIPTION
from this:

https://github.com/Tencent/puerts/blob/5d35e50132f7cb950c4b84ef263d124f49b7d0a5/unreal/Puerts/Source/ParamDefaultValueMetas/Private/ParamDefaultValueMetasModule.cpp#L12

it's pretty clear we should do this to ReactUMG as well